### PR TITLE
Use the resourceURI as the base path for model creation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.janeirodigital</groupId>
     <artifactId>shapetrees-java</artifactId>
-    <version>0.5.7</version>
+    <version>0.5.8</version>
 
     <packaging>pom</packaging>
 

--- a/shapetrees/pom.xml
+++ b/shapetrees/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.janeirodigital</groupId>
         <artifactId>shapetrees-java</artifactId>
-        <version>0.5.7</version>
+        <version>0.5.8</version>
     </parent>
 
     <dependencies>

--- a/shapetrees/src/main/java/com/janeirodigital/shapetrees/client/impl/ShapeTreeClientImpl.java
+++ b/shapetrees/src/main/java/com/janeirodigital/shapetrees/client/impl/ShapeTreeClientImpl.java
@@ -206,7 +206,7 @@ public class ShapeTreeClientImpl implements ShapeTreeClient {
 
         // Build a model and a dataset to apply the patch to an in-memory graph.
         Model model = ModelFactory.createDefaultModel();
-        model.read(new ByteArrayInputStream(resourceContent.getBytes(StandardCharsets.UTF_8)), null, "TURTLE");
+        model.read(new ByteArrayInputStream(resourceContent.getBytes(StandardCharsets.UTF_8)), resourceURI.toString(), "TURTLE");
         Dataset dataset = new DatasetOne(model);
         UpdateAction.parseExecute(queryString, dataset);
         UpdateAction.parseExecute(QueryHelper.removeManagedTriplesQuery(resourceURI.toString()), dataset);


### PR DESCRIPTION
Jena applies the baseIRI at model read time, so we need to pass it so that the relative URLs don't resolve to the working directory.