### PR TITLE
Use the write syntax for DELETE with variable values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.janeirodigital</groupId>
     <artifactId>shapetrees-java</artifactId>
-    <version>0.5.9</version>
+    <version>0.5.10</version>
 
     <packaging>pom</packaging>
 

--- a/shapetrees/pom.xml
+++ b/shapetrees/pom.xml
@@ -12,7 +12,7 @@
     <parent>
         <groupId>com.janeirodigital</groupId>
         <artifactId>shapetrees-java</artifactId>
-        <version>0.5.9</version>
+        <version>0.5.10</version>
     </parent>
 
     <dependencies>

--- a/shapetrees/src/main/java/com/janeirodigital/shapetrees/helper/QueryHelper.java
+++ b/shapetrees/src/main/java/com/janeirodigital/shapetrees/helper/QueryHelper.java
@@ -7,8 +7,8 @@ public class QueryHelper {
      * @return
      */
     public static String removeManagedTriplesQuery() {
-        return "DELETE { ?s ?p ?o } \n" +
-               "WHERE { ?s <http://www.w3.org/ns/ldp#contains> ?o }";
+        return "PREFIX ldp: <http://www.w3.org/ns/ldp#> \n" +
+               "DELETE WHERE { ?s ldp:contains ?o . }";
     }
 
 }


### PR DESCRIPTION
The SPARQL  syntax for deleting triples with unknown/variable nodes is different than when inserting/deleting concrete nodes. The new query correctly identifies the triples to delete.