### PR TITLE
~ AbstractHttpClientFactory.getFactory() throws ShapeTreeException

### DIFF
--- a/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/AbstractHttpClientFactory.java
+++ b/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/AbstractHttpClientFactory.java
@@ -1,10 +1,16 @@
 package com.janeirodigital.shapetrees.client.http;
 
-import lombok.Getter;
+import com.janeirodigital.shapetrees.core.exceptions.ShapeTreeException;
 import lombok.Setter;
 import lombok.Synchronized;
 
 public abstract class AbstractHttpClientFactory {
-    @Setter(onMethod_={@Synchronized}) @Getter(onMethod_={@Synchronized})
+    @Setter(onMethod_={@Synchronized})
     private static HttpClientFactory factory;
+
+    @Synchronized
+    public static HttpClientFactory getFactory() throws ShapeTreeException {
+        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
+        return AbstractHttpClientFactory.factory;
+    }
 }

--- a/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/HttpRemoteResource.java
+++ b/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/HttpRemoteResource.java
@@ -206,10 +206,7 @@ public class HttpRemoteResource {
         StringWriter sw = new StringWriter();
         RDFDataMgr.write(sw, updatedGraph, Lang.TURTLE);
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-
-        HttpClient fetcher = factory.get(false);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(false);
         fetcher.fetchShapeTreeResponse("PUT", this.uri, null, authorizationHeaderValue, sw.toString(), TEXT_TURTLE);
 
         if (Boolean.TRUE.equals(refreshResourceAfterUpdate)) {
@@ -274,10 +271,7 @@ public class HttpRemoteResource {
         log.debug("HttpRemoteResource#dereferencingURI({})", this.uri);
 
         try {
-            HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-            if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-
-            HttpClient fetcher = factory.get(false);
+            HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(false);
             fetcher.fetchIntoRemoteResource("GET", this.uri, null, authorizationHeaderValue, null, null, this);
             this.invalidated = false;
         } catch (Exception e) {

--- a/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/HttpRemoteResourceAccessor.java
+++ b/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/HttpRemoteResourceAccessor.java
@@ -75,10 +75,7 @@ public class HttpRemoteResourceAccessor implements ResourceAccessor {
     public ShapeTreeResource createResource(ShapeTreeContext context, String method, URI resourceURI, Map<String, List<String>> headers, String body, String contentType) throws ShapeTreeException {
         log.debug("createResource via {}: URI [{}], headers [{}]", method, resourceURI, writeHeaders(headers));
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-
-        HttpClient fetcher = factory.get(false);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(false);
         return fetcher.fetchShapeTreeResource(method, resourceURI, headers, context.getAuthorizationHeaderValue(), body, contentType);
     }
 
@@ -87,10 +84,7 @@ public class HttpRemoteResourceAccessor implements ResourceAccessor {
         log.debug("updateResource: URI [{}]", updatedResource.getUri());
 
         String contentType = updatedResource.getFirstAttributeValue(HttpHeaders.CONTENT_TYPE.getValue());
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-
-        HttpClient fetcher = factory.get(false);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(false);
         return fetcher.fetchShapeTreeResource(method, updatedResource.getUri(), updatedResource.getAttributes(), context.getAuthorizationHeaderValue(), updatedResource.getBody(), contentType);
     }
 
@@ -98,10 +92,7 @@ public class HttpRemoteResourceAccessor implements ResourceAccessor {
     public ShapeTreeResponse deleteResource(ShapeTreeContext context, ShapeTreeResource deletedResource) throws ShapeTreeException {
         log.debug("deleteResource: URI [{}]", deletedResource.getUri());
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-
-        HttpClient fetcher = factory.get(false);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(false);
         ShapeTreeResponse response = fetcher.fetchShapeTreeResponse("DELETE", deletedResource.getUri(), deletedResource.getAttributes(), context.getAuthorizationHeaderValue(), null, null);
         int respCode = response.getStatusCode();
         if (respCode < 200 || respCode >= 400) {

--- a/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/HttpShapeTreeClient.java
+++ b/shapetrees-java-client-http/src/main/java/com/janeirodigital/shapetrees/client/http/HttpShapeTreeClient.java
@@ -146,9 +146,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
         RDFDataMgr.write(sw, locator.getGraph(), Lang.TURTLE);
 
         // Build an HTTP PUT request with the locator graph in turtle as the content body + link header
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse("PUT", new URI(resource.getMetadataURI()), null, context.getAuthorizationHeaderValue(), sw.toString(), "text/turtle");
     }
 
@@ -164,9 +162,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
         log.debug ("Target Shape Tree: {}", targetShapeTree == null ? "None provided" : targetShapeTree.toString());
         log.debug("Focus Node: {}", focusNode == null ? "None provided" : focusNode.toString());
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse("POST", parentContainer,
                                               getCommonHeaders(context, focusNode, targetShapeTree, isContainer,
                                                                proposedResourceName, contentType),
@@ -186,9 +182,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
         log.debug ("Target Shape Tree: {}", targetShapeTree == null ? "None provided" : targetShapeTree.toString());
         log.debug("Focus Node: {}", focusNode == null ? "None provided" : focusNode);
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse("PUT", resourceURI,
                                               getCommonHeaders(context, focusNode, targetShapeTree, isContainer,
                                               null, contentType),
@@ -207,9 +201,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
         log.debug("Updating shape tree instance via PUT at {}", resourceURI);
         log.debug("Focus Node: {}", focusNode == null ? "None provided" : focusNode);
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse("PUT", resourceURI,
                                               getCommonHeaders(context, focusNode, null, null, null, contentType),
                                               null, bodyString,
@@ -229,9 +221,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
 
         String contentType = "application/sparql-update";
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse("PATCH", resourceURI,
                                               getCommonHeaders(context, focusNode, null, null, null, contentType),
                                               null, patchString,
@@ -247,9 +237,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
 
         log.debug("DELETE-ing shape tree instance at {}", resourceURI);
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse("DELETE", resourceURI,
                                               getCommonHeaders(context, null, null, null, null, null),
                                               null, null,
@@ -301,9 +289,7 @@ public class HttpShapeTreeClient implements ShapeTreeClient {
             contentType = "text/turtle";
         }
 
-        HttpClientFactory factory = AbstractHttpClientFactory.getFactory();
-        if (factory == null) { throw new ShapeTreeException(500, "Must provide a valid HTTP client factory"); }
-        HttpClient fetcher = factory.get(useClientShapeTreeValidation);
+        HttpClient fetcher = AbstractHttpClientFactory.getFactory().get(useClientShapeTreeValidation);
         return fetcher.fetchShapeTreeResponse(method, new URI(resource.getMetadataURI()),
                                               null, // why no getCommonHeaders(context, null, null, null, null, null) ?
                                               null, body, contentType);


### PR DESCRIPTION
removes ceremony around getting a factory
if someone really wants to poll ('cause their code doesn't keep track of whether the factory is set), they can wrap it in a try.

Merging this PR will help me merge a bunch of others.