### PR TITLE
Use linear time regex

### DIFF
--- a/shapetrees-java-core/pom.xml
+++ b/shapetrees-java-core/pom.xml
@@ -34,6 +34,11 @@
             <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.re2j</groupId>
+            <artifactId>re2j</artifactId>
+            <version>1.6</version>
+        </dependency>
+        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.version}</version>

--- a/shapetrees-java-core/src/main/java/com/janeirodigital/shapetrees/core/resources/ResourceAttributes.java
+++ b/shapetrees-java-core/src/main/java/com/janeirodigital/shapetrees/core/resources/ResourceAttributes.java
@@ -1,9 +1,10 @@
 package com.janeirodigital.shapetrees.core.resources;
+
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import static java.util.Objects.requireNonNull;
 

--- a/shapetrees-java-core/src/main/java/com/janeirodigital/shapetrees/core/validation/ShapeTreeReference.java
+++ b/shapetrees-java-core/src/main/java/com/janeirodigital/shapetrees/core/validation/ShapeTreeReference.java
@@ -1,5 +1,7 @@
 package com.janeirodigital.shapetrees.core.validation;
 
+import com.google.re2j.Matcher;
+import com.google.re2j.Pattern;
 import com.janeirodigital.shapetrees.core.exceptions.ShapeTreeException;
 import lombok.Getter;
 import org.apache.jena.rdf.model.Property;
@@ -8,8 +10,6 @@ import org.apache.jena.rdf.model.ResourceFactory;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.Objects;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Getter
 public class ShapeTreeReference {

--- a/shapetrees-java-core/src/main/java/com/janeirodigital/shapetrees/core/validation/ShapeTreeReference.java
+++ b/shapetrees-java-core/src/main/java/com/janeirodigital/shapetrees/core/validation/ShapeTreeReference.java
@@ -47,7 +47,7 @@ public class ShapeTreeReference {
         if (reference.viaShapePath()) {
             // TODO - this is a bit of a workaround to extract the target property from the shape path, given the
             // TODO - current lack of a shape path parser in java. It is functionally equivalent to viaPredicate
-            Pattern pattern = Pattern.compile("@\\S+~(\\S*$)");
+            Pattern pattern = Pattern.compile("^@<?\\S+>?~(<?\\S*>?$)");
             Matcher matcher = pattern.matcher(reference.getShapePath());
             if (!matcher.matches()) return null;
             String parsed = matcher.group(1);


### PR DESCRIPTION
Addresses potential for denial of service through specially crafted strings designed to hang the regular expression engine by using google's linear time regex engine instead of java built-in.